### PR TITLE
Don't use a thread pool for update check

### DIFF
--- a/src/main/java/it/frafol/cleanstaffchat/bukkit/UpdateCheck.java
+++ b/src/main/java/it/frafol/cleanstaffchat/bukkit/UpdateCheck.java
@@ -17,8 +17,7 @@ public class UpdateCheck {
     }
 
     public void getVersion(final Consumer<String> consumer) {
-        ScheduledThreadPoolExecutor service = new ScheduledThreadPoolExecutor(1);
-        service.schedule(() -> {
+        new Thread(() -> {
             try (InputStream inputStream = new URL("https://api.spigotmc.org/legacy/update.php?resource=105220")
                     .openStream(); Scanner scanner = new Scanner(inputStream)) {
                 if (scanner.hasNext()) {
@@ -27,6 +26,6 @@ public class UpdateCheck {
             } catch (IOException exception) {
                 PLUGIN.getLogger().severe("Unable to check for updates: " + exception.getMessage());
             }
-        }, 0, TimeUnit.MILLISECONDS);
+        }, "CleanStaffChat-Updater").start();
     }
 }


### PR DESCRIPTION
Avoids a potential memory leak due to not closing the thread pool